### PR TITLE
doc: fix URL in doc string

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ platform-plugin-notices
 |pypi-badge| |ci-badge| |codecov-badge| |doc-badge| |pyversions-badge|
 |license-badge|
 
-* This repo is not currently accepting open source contributions *
+*This repo is not currently accepting open source contributions*
 
 Overview
 --------

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ platform-plugin-notices
 |pypi-badge| |ci-badge| |codecov-badge| |doc-badge| |pyversions-badge|
 |license-badge|
 
-*This repo is not currently accepting open source contributions*
+**This repo is not currently accepting open source contributions**
 
 Overview
 --------

--- a/README.rst
+++ b/README.rst
@@ -4,9 +4,10 @@ platform-plugin-notices
 |pypi-badge| |ci-badge| |codecov-badge| |doc-badge| |pyversions-badge|
 |license-badge|
 
+* This repo is not currently accepting open source contributions *
 
 Overview
-------------------------
+--------
 
 This plugin for edx-platform manages notices that a user must acknowledge. It only stores the content of the notices and whether a user has acknowledged them. Presentation and other client side decisions will be left to the frontends that utilize these APIs.
 

--- a/notices/rest_api/v1/views.py
+++ b/notices/rest_api/v1/views.py
@@ -16,7 +16,7 @@ class ListUnacknowledgedNotices(APIView):
     """
     Read only view to list all notices that the user hasn't acknowledged.
 
-    Path: `/api/notices/v1/unacknowledged`
+    Path: `/notices/api/v1/unacknowledged`
 
     Returns:
       * 200: OK - Contains a list of active unacknowledged notices the user still needs to see


### PR DESCRIPTION
**Description:**
Fix a doc string and notes that the repo isn't open to external contributions at this time.

**Merge checklist:**
- [ ] Bump version
- [ ] Add to changelog
- [ ] Update docs (not only docstrings)

**Post merge:**
(Will eventually be handled via automation)
- [ ] Release with new tag matching version

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
