### PR TITLE
feat: add js utils to simplify notice code

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,23 @@ Unreleased
 
 *
 
+[0.2.1] - 2021-09-22
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Added
+_____
+
+* Utility functions for custom notice code to use to call APIs
+
+[0.1.1] - 2021-09-16
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Added
+_____
+
+* Moved to server rendered notice model
+* Add mandatory types to acknowledgement to track more states
+
 [0.1.0] - 2021-08-19
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/notices/__init__.py
+++ b/notices/__init__.py
@@ -2,6 +2,6 @@
 An edx-platform plugin which manages notices that must be acknowledged.
 """
 
-__version__ = "0.1.1"
+__version__ = "0.2.1"
 
 default_app_config = "notices.apps.NoticesConfig"  # pylint: disable=invalid-name

--- a/notices/static/notices/js/utils.js
+++ b/notices/static/notices/js/utils.js
@@ -1,0 +1,39 @@
+const ACKNOWLEDGMENT_TYPES = {
+  DISMISSED: "dismissed",
+  CONFIRMED: "confirmed"
+}
+
+function confirmNoticeClick(){
+  sendAcknowledgment(ACKNOWLEDGMENT_TYPES.CONFIRMED, forwardingUrl)
+}
+
+function dismissNoticeClick(event){
+  let nextUrl;
+  if (event.target.href){
+    // If caller is a link, stop redirection until after API call.
+    event.preventDefault();
+    nextUrl = event.target.href;
+  } else {
+    nextUrl = forwardingUrl;
+  }
+  sendAcknowledgment(ACKNOWLEDGMENT_TYPES.DISMISSED, nextUrl)
+};
+
+function sendAcknowledgment(type, url){
+  const callback = () => {
+    window.location = url;
+  }
+  const csrftoken = document.querySelector('[name=csrfmiddlewaretoken]').value;
+  let params = { notice_id: noticeId, acknowledgment_type: type};
+  let postRequest = new XMLHttpRequest();
+  postRequest.open("POST", "/notices/api/v1/acknowledge");
+  postRequest.setRequestHeader("Content-type", "application/json");
+  postRequest.setRequestHeader("X-CSRFToken", csrftoken);
+  postRequest.send(JSON.stringify(params));
+  postRequest.onreadystatechange = () => {
+    if (postRequest.readyState === 4 && postRequest.status === 204) {
+      console.log("acknowledgment successful");
+      callback();
+    }
+  };
+}

--- a/notices/templates/notice.html
+++ b/notices/templates/notice.html
@@ -1,11 +1,17 @@
+{% load static %}
 <html>
 <head>
+    <script>
+        // Global constants so the notice and shared JS can pull the values easily.
+        const forwardingUrl = "{{ forwarding_url }}";
+        const noticeId = {{ notice_id }};
+    </script>
+    <script src="{% static 'notices/js/utils.js' %}"></script>
     {{ head_content|safe }}
 </head>
 <body>
-    <!-- This is so the javascript can pull a validated forwarding URL from the page -->
-    <div aria-hidden="true" id="redirect_path" style="display:none">{{ forwarding_url }}</div>
     {{ html_content|safe }}
+    {% csrf_token %}
 </body>
 </html>
 

--- a/notices/views.py
+++ b/notices/views.py
@@ -41,6 +41,7 @@ class RenderNotice(DetailView):
                 "head_content": self.object.head_content,
                 "html_content": body_content,
                 "forwarding_url": forwarding_url,
+                "notice_id": self.object.id,
             }
         )
         return context


### PR DESCRIPTION
Adds onclick handlers to confirm and dismiss notices. This way the
custom notice javascript can just set elements onclick attribute to
these to avoid custom acknowledgment code.

**Description:**
Describe in a couple of sentences what this PR adds

**Merge checklist:**
- [ ] Bump version
- [ ] Add to changelog
- [ ] Update docs (not only docstrings)

**Post merge:**
(Will eventually be handled via automation)
- [ ] Release with new tag matching version

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
