### PR TITLE
feat: allow inactive users to call API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Unreleased
 
 *
 
+[0.4.1] - 2021-10-7
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Allow inactive (non-email-verified) users to call APIs
+
 [0.3.1] - 2021-10-1
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Add mobile calls so notice code can deep link

--- a/notices/__init__.py
+++ b/notices/__init__.py
@@ -2,6 +2,6 @@
 An edx-platform plugin which manages notices that must be acknowledged.
 """
 
-__version__ = "0.3.1"
+__version__ = "0.4.1"
 
 default_app_config = "notices.apps.NoticesConfig"  # pylint: disable=invalid-name

--- a/notices/rest_api/v1/views.py
+++ b/notices/rest_api/v1/views.py
@@ -1,5 +1,6 @@
 """API views for the notices app"""
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
 from rest_framework import permissions
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
@@ -19,7 +20,7 @@ from notices.models import AcknowledgedNotice, Notice
 
 
 # Pulling this out so tests can ignore Bearer auth since we won't have platform importable in tests
-COMMON_AUTH_CLASSES = [JwtAuthentication, SessionAuthentication]
+COMMON_AUTH_CLASSES = [JwtAuthentication, SessionAuthentication, SessionAuthenticationAllowInactiveUser]
 if BearerAuthenticationAllowInactiveUser is not None:
     COMMON_AUTH_CLASSES.append(BearerAuthenticationAllowInactiveUser)
 


### PR DESCRIPTION
Mobile users can stay in an inactive state for a long time /
indefinitely. This allows them to use the API still.

**Description:**
Describe in a couple of sentences what this PR adds

**Merge checklist:**
- [x] Bump version
- [x] Add to changelog
- [x] Update docs (not only docstrings)

**Post merge:**
(Will eventually be handled via automation)
- [ ] Release with new tag matching version

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
