### PR TITLE
feat: Add Python and Plugin Context APIs to support LMS course dashboard redirects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,9 +14,12 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
-*
+[0.6.1] - 2021-10-7
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Add Python API for retrieving unack'd and active notice data
+* Add Plugin Context API for notice data to support redirects on the LMS Course Dashboard
 
-[0.5.1] - 2021-10-1
+[0.5.1] - 2021-10-7
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Disallow dismissal after confirmation of notice
 

--- a/notices/__init__.py
+++ b/notices/__init__.py
@@ -2,6 +2,6 @@
 An edx-platform plugin which manages notices that must be acknowledged.
 """
 
-__version__ = "0.5.1"
+__version__ = "0.6.1"
 
 default_app_config = "notices.apps.NoticesConfig"  # pylint: disable=invalid-name

--- a/notices/api.py
+++ b/notices/api.py
@@ -1,0 +1,26 @@
+"""
+Python API for Notice data.
+"""
+from rest_framework.reverse import reverse
+
+from notices.selectors import get_visible_notices
+
+
+def get_unacknowledged_notices_for_user(user, in_app=False, request=None):
+    """
+    Retrieve a list of all unacknowledged (active) Notices for a given user.
+
+    Returns:
+        (list): A (text) list of URLs to the unack'd Notices.
+    """
+    unacknowledged_active_notices = get_visible_notices(user)
+
+    urls = []
+    if unacknowledged_active_notices:
+        urls = [
+            reverse("notices:notice-detail", kwargs={"pk": notice.id}, request=request)
+            + ("?mobile=true" if in_app else "")
+            for notice in unacknowledged_active_notices
+        ]
+
+    return urls

--- a/notices/apps.py
+++ b/notices/apps.py
@@ -26,4 +26,5 @@ class NoticesConfig(AppConfig):
                 "common": {"relative_path": "settings.common"},
             }
         },
+        "view_context_config": {"lms.djangoapp": {"course_dashboard": "notices.context_api.get_dashboard_context"}},
     }

--- a/notices/context_api.py
+++ b/notices/context_api.py
@@ -1,0 +1,21 @@
+"""
+Functions to add context to LMS pages via the plugins context feature.
+"""
+from django.conf import settings
+
+from .api import get_unacknowledged_notices_for_user
+
+
+def get_dashboard_context(existing_context):
+    """
+    Return additional context for the course dashboard.
+    """
+    user = existing_context.get("user")
+
+    data = None
+    if settings.FEATURES.get("ENABLE_NOTICES") and user:
+        data = get_unacknowledged_notices_for_user(user)
+
+    return {
+        "unacknowledged_notices": data,
+    }

--- a/notices/selectors.py
+++ b/notices/selectors.py
@@ -1,0 +1,32 @@
+"""
+Utility functions for pulling Notice data.
+"""
+from django.db.models.query_utils import Q
+
+from notices.models import AcknowledgedNotice, Notice
+
+
+def get_active_notices():
+    """
+    Return a QuerySet of all active Notices.
+    """
+    return Notice.objects.filter(active=True)
+
+
+def get_acknowledged_notices_for_user(user):
+    """
+    Return a QuerySet of all acknowledged Notices for a given user.
+    """
+    return AcknowledgedNotice.objects.filter(user=user)
+
+
+def get_visible_notices(user):
+    """
+    Return a QuerySet of all active and unacknowledged Notices for a given user.
+    """
+    active_notices = get_active_notices()
+    acknowledged_notices = get_acknowledged_notices_for_user(user)
+
+    query = Q(id__in=[acked.notice.id for acked in acknowledged_notices])
+
+    return active_notices.exclude(query)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,59 @@
+"""
+Tests for the Notices app's Python API
+"""
+from django.test import TestCase
+from rest_framework.reverse import reverse
+
+from notices.api import get_unacknowledged_notices_for_user
+from notices.data import AcknowledgmentResponseTypes
+from test_utils.factories import AcknowledgedNoticeFactory, NoticeFactory, UserFactory
+
+
+class TestPythonApi(TestCase):
+    """
+    Tests for the Notices app's exposed Python API.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory()
+
+    def test_unackd_active_notices(self):
+        """
+        Happy path. Verifies that only active and unack'd notice ids are returned to the caller.
+        """
+        notice = NoticeFactory(active=True)
+        notice2 = NoticeFactory(active=True)
+        notice3 = NoticeFactory(active=True)
+        notice4 = NoticeFactory(active=True)
+        NoticeFactory(active=False)
+
+        AcknowledgedNoticeFactory(user=self.user, notice=notice2, response_type=AcknowledgmentResponseTypes.CONFIRMED)
+        AcknowledgedNoticeFactory(user=self.user, notice=notice3, response_type=AcknowledgmentResponseTypes.DISMISSED)
+
+        expected_results = [
+            reverse("notices:notice-detail", kwargs={"pk": notice.id}),
+            reverse("notices:notice-detail", kwargs={"pk": notice4.id}),
+        ]
+
+        results = get_unacknowledged_notices_for_user(self.user)
+        assert results == expected_results
+
+    def test_no_unackd_notices_for_user(self):
+        """
+        Verifies an empty list is returned if a user has no unack'd notices.
+        """
+        notice = NoticeFactory(active=True)
+        AcknowledgedNoticeFactory(user=self.user, notice=notice, response_type=AcknowledgmentResponseTypes.CONFIRMED)
+
+        results = get_unacknowledged_notices_for_user(self.user)
+        assert results == []
+
+    def test_no_active_notices_for_user(self):
+        """
+        Verifies an empty list is returned if a user has no active notices.
+        """
+        NoticeFactory(active=False)
+
+        results = get_unacknowledged_notices_for_user(self.user)
+        assert results == []

--- a/tests/test_context_api.py
+++ b/tests/test_context_api.py
@@ -1,0 +1,72 @@
+"""
+Tests for the plugin context functions.
+"""
+from django.test import TestCase
+from django.test.utils import override_settings
+from rest_framework.reverse import reverse
+
+from notices.context_api import get_dashboard_context
+from notices.data import AcknowledgmentResponseTypes
+from test_utils.factories import AcknowledgedNoticeFactory, NoticeFactory, UserFactory
+
+
+@override_settings(FEATURES={"ENABLE_NOTICES": True})
+class TestContextApi(TestCase):
+    """
+    Tests for the data that gets passed to the course dashboard via context plugins.
+    """
+
+    def create_expected_results(self, data):
+        return {
+            "unacknowledged_notices": data,
+        }
+
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory()
+        self.context = {"user": self.user}
+
+    def test_get_context(self):
+        """
+        Happy path. Verifies that only active and unack'd notice data is returned in context data.
+        """
+        notice = NoticeFactory(active=True)
+        notice2 = NoticeFactory(active=True)
+        notice3 = NoticeFactory(active=True)
+        notice4 = NoticeFactory(active=True)
+        NoticeFactory(active=False)
+
+        AcknowledgedNoticeFactory(user=self.user, notice=notice2, response_type=AcknowledgmentResponseTypes.CONFIRMED)
+        AcknowledgedNoticeFactory(user=self.user, notice=notice3, response_type=AcknowledgmentResponseTypes.DISMISSED)
+
+        expected_data = [
+            reverse("notices:notice-detail", kwargs={"pk": notice.id}),
+            reverse("notices:notice-detail", kwargs={"pk": notice4.id}),
+        ]
+        expected_results = self.create_expected_results(expected_data)
+
+        results = get_dashboard_context(self.context)
+        assert results == expected_results
+
+    def test_get_context_no_unackd_notices_for_user(self):
+        """
+        Verifies that acknowledged notice data isn't returned in context data.
+        """
+        notice = NoticeFactory(active=True)
+        AcknowledgedNoticeFactory(user=self.user, notice=notice, response_type=AcknowledgmentResponseTypes.CONFIRMED)
+
+        expected_results = self.create_expected_results([])
+
+        results = get_dashboard_context(self.context)
+        assert results == expected_results
+
+    def test_get_context_no_active_notices_for_user(self):
+        """
+        Verifies that inactive notice data isn't returned in context data.
+        """
+        NoticeFactory(active=False)
+
+        expected_results = self.create_expected_results([])
+
+        results = get_dashboard_context(self.context)
+        assert results == expected_results

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -1,0 +1,34 @@
+"""
+Tests for the Notices app's data fetching utilities.
+"""
+from django.test import TestCase
+
+from notices.data import AcknowledgmentResponseTypes
+from notices.selectors import get_visible_notices
+from test_utils.factories import AcknowledgedNoticeFactory, NoticeFactory, UserFactory
+
+
+class TestSelectors(TestCase):
+    """
+    Test for Selector functions business logic.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory()
+
+    def test_get_visible_notices(self):
+        """
+        Happy path. Verifies that "visible" (active and unacknowledged) notice data is returned as expected for a user.
+        """
+        active_notice = NoticeFactory(active=True)
+        active_notice2 = NoticeFactory(active=True)
+        active_notice_acked = NoticeFactory(active=True)
+        NoticeFactory(active=False)
+
+        AcknowledgedNoticeFactory(
+            user=self.user, notice=active_notice_acked, response_type=AcknowledgmentResponseTypes.CONFIRMED
+        )
+
+        results = get_visible_notices(self.user)
+        assert list(results) == [active_notice, active_notice2]


### PR DESCRIPTION
[MICROBA-1520]

- Add `context_api.py` that will return Notice data to support passing data to the (LMS) course dashboard
- Add `api.py` exposing a Python API for retrieving Notice data
- Add `selectors.py` for fetching data
- Update `views.py` to retrieve data from the new Python API

**Merge checklist:**
- [X] Bump version
- [X] Add to changelog
- [ ] Update docs (not only docstrings)

**Post merge:**
(Will eventually be handled via automation)
- [ ] Release with new tag matching version

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
