### PR TITLE
perf: Make user readonly for admin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.7.2] - 2021-10-19
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Make AcknowledgedNotice user readonly in the admin for performance
+
 [0.7.1] - 2021-10-19
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Add Waffle Flag to enable and disable the feature for rollout

--- a/notices/__init__.py
+++ b/notices/__init__.py
@@ -2,6 +2,6 @@
 An edx-platform plugin which manages notices that must be acknowledged.
 """
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"
 
 default_app_config = "notices.apps.NoticesConfig"  # pylint: disable=invalid-name

--- a/notices/admin.py
+++ b/notices/admin.py
@@ -16,4 +16,4 @@ class NoticeAdmin(admin.ModelAdmin):
 
 @admin.register(AcknowledgedNotice)
 class AcknowledgedNoticeAdmin(admin.ModelAdmin):
-    pass
+    readonly_fields = ["user"]


### PR DESCRIPTION
Having the default dropdown kills stage/prod. We could move to a
search field, but we shouldn't need to change the user on these.

**Description:**
Describe in a couple of sentences what this PR adds

**Merge checklist:**
- [x] Bump version
- [x] Add to changelog
- [x] Update docs (not only docstrings)

**Post merge:**
(Will eventually be handled via automation)
- [ ] Release with new tag matching version

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
