### PR TITLE
feat: MICROBA-1533 add segment tracking to notice

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.10.0] - 2021-10-25
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Add segment library for event tracking
+
 [0.9.0] - 2021-10-25
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Add in a snooze limit feature that will only allow a notice to be snoozed a number of times

--- a/notices/__init__.py
+++ b/notices/__init__.py
@@ -2,6 +2,6 @@
 An edx-platform plugin which manages notices that must be acknowledged.
 """
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"
 
 default_app_config = "notices.apps.NoticesConfig"  # pylint: disable=invalid-name

--- a/notices/settings/common.py
+++ b/notices/settings/common.py
@@ -6,5 +6,6 @@ def plugin_settings(settings):
     settings.FEATURES["NOTICES_REDIRECT_ALLOWLIST"] = []
     settings.FEATURES["NOTICES_DEFAULT_REDIRECT_URL"] = "http://www.example.com"
     settings.FEATURES["NOTICES_FALLBACK_LANGUAGE"] = "en"
+    settings.FEATURES["NOTICES_SEGMENT_KEY"] = None
     settings.FEATURES["NOTICES_SNOOZE_HOURS"] = None
     settings.FEATURES["NOTICES_SNOOZE_COUNT_LIMIT"] = None

--- a/notices/settings/production.py
+++ b/notices/settings/production.py
@@ -18,3 +18,6 @@ def plugin_settings(settings):
     settings.FEATURES["NOTICES_SNOOZE_COUNT_LIMIT"] = settings.ENV_TOKENS.get(
         "NOTICES_SNOOZE_COUNT_LIMIT", settings.FEATURES["NOTICES_SNOOZE_COUNT_LIMIT"]
     )
+    settings.FEATURES["NOTICES_SEGMENT_KEY"] = settings.AUTH_TOKENS.get(
+        "NOTICES_SEGMENT_KEY", settings.FEATURES["NOTICES_SEGMENT_KEY"]
+    )

--- a/notices/templates/notice.html
+++ b/notices/templates/notice.html
@@ -10,6 +10,29 @@
     </script>
     <script src="{% static 'notices/js/utils.js' %}"></script>
     {{ head_content|safe }}
+{% if settings.NOTICES_SEGMENT_KEY %}
+<!-- begin Segment -->
+<script type="text/javascript">
+  // Asynchronously load Segment's analytics.js library
+  !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="3.1.0";
+  analytics.load("${ settings.NOTICES_SEGMENT_KEY | n, js_escaped_string }");
+  analytics.page();
+  }}();
+  // Note: user tracking moved to segment-io-footer.html
+</script>
+<!-- end Segment -->
+{% else %}
+<!-- dummy Segment -->
+<script type="text/javascript">
+  var analytics = {
+    track: function() { return; },
+    trackLink: function() { return; },
+    pageview: function() { return; },
+    page: function() { return; }
+  };
+</script>
+<!-- end dummy Segment -->
+{% endif %}
 </head>
 <body>
     {{ html_content|safe }}

--- a/notices/views.py
+++ b/notices/views.py
@@ -53,6 +53,7 @@ class RenderNotice(LoginRequiredMixin, DetailView):
                 "notice_id": self.object.id,
                 "in_app": in_app,
                 "can_dismiss": can_dismiss(self.request.user, self.object),
+                "NOTICES_SEGMENT_KEY": settings.FEATURES["NOTICES_SEGMENT_KEY"],
             }
         )
         return context


### PR DESCRIPTION
**Description:**
Describe in a couple of sentences what this PR adds

Adds the segment tracking library to the context of the notice template. The actual tracking events will be handled by the template itself. 

**Merge checklist:**
- [X] Bump version
- [X] Add to changelog
- [X] Update docs (not only docstrings)

**Post merge:**
(Will eventually be handled via automation)
- [ ] Release with new tag matching version

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
