### PR TITLE
feat: allow failing API to still continue

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+[0.11.3] - 2021-11-05
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Allow user to leave page even if API call fails (important for mobile)
 
 [0.11.2] - 2021-11-04
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/notices/__init__.py
+++ b/notices/__init__.py
@@ -2,6 +2,6 @@
 An edx-platform plugin which manages notices that must be acknowledged.
 """
 
-__version__ = "0.11.2"
+__version__ = "0.11.3"
 
 default_app_config = "notices.apps.NoticesConfig"  # pylint: disable=invalid-name

--- a/notices/static/notices/js/utils.js
+++ b/notices/static/notices/js/utils.js
@@ -34,6 +34,11 @@ function sendAcknowledgment(type, url){
   postRequest.onreadystatechange = () => {
     if (postRequest.readyState === 4 && postRequest.status === 204) {
       console.log("acknowledgment successful");
+      window.analytics.track('edx.bi.user.acknowledged_acqusition', {acknowledgment_type: type});
+      callback();
+    } else if (postRequest.readyState === 4 && postRequest.status !== 204) {
+      /* We need to let the user exit even on a failure because mobile users can get stuck otherwise */
+      console.log(`acknowledgement failed. Error: ${postRequest.responseText}`)
       callback();
     }
   };


### PR DESCRIPTION
Mobile needs to be able to leave screen even if API call fails.

**Description:**
Describe in a couple of sentences what this PR adds

**Merge checklist:**
- [x] Bump version
- [x] Add to changelog
- [x] Update docs (not only docstrings)

**Post merge:**
(Will eventually be handled via automation)
- [ ] Release with new tag matching version

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
