### PR TITLE
feat: add lang tag to html element

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+[0.11.5] - 2021-11-09
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Add lang tag to HTML element
+
 [0.11.4] - 2021-11-08
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Change name of segment event from "acquisition" to "notice"

--- a/notices/__init__.py
+++ b/notices/__init__.py
@@ -2,6 +2,6 @@
 An edx-platform plugin which manages notices that must be acknowledged.
 """
 
-__version__ = "0.11.4"
+__version__ = "0.11.5"
 
 default_app_config = "notices.apps.NoticesConfig"  # pylint: disable=invalid-name

--- a/notices/templates/notice.html
+++ b/notices/templates/notice.html
@@ -1,5 +1,5 @@
 {% load static %}
-<html>
+<html lang="{{ user_language }}">
 <head>
     <script>
         // Global constants so the notice and shared JS can pull the values easily.

--- a/notices/views.py
+++ b/notices/views.py
@@ -47,6 +47,7 @@ class RenderNotice(LoginRequiredMixin, DetailView):
         in_app = self.request.GET.get("mobile") == "true"
         context.update(
             {
+                "user_language": user_language,
                 "head_content": self.object.head_content,
                 "html_content": body_content,
                 "forwarding_url": forwarding_url,


### PR DESCRIPTION
**Description:**

The HTML element should have a `lang` attribute with the language code
for each language.

**Merge checklist:**
- [ ] Bump version
- [ ] Add to changelog
- [ ] Update docs (not only docstrings)

**Post merge:**
(Will eventually be handled via automation)
- [ ] Release with new tag matching version

**Author concerns:** None.
