### PR TITLE
feat: add userLanguage flag

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.11.7] - 2021-11-10
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Add userLanguage flag so JavaScript-rendered text can be displayed in the correct language
+
 [0.11.6] - 2021-11-10
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Add mobile flag so mobile can be disabled in production

--- a/notices/__init__.py
+++ b/notices/__init__.py
@@ -2,6 +2,6 @@
 An edx-platform plugin which manages notices that must be acknowledged.
 """
 
-__version__ = "0.11.6"
+__version__ = "0.11.7"
 
 default_app_config = "notices.apps.NoticesConfig"  # pylint: disable=invalid-name

--- a/notices/templates/notice.html
+++ b/notices/templates/notice.html
@@ -3,6 +3,7 @@
 <head>
     <script>
         // Global constants so the notice and shared JS can pull the values easily.
+        const userLanguage = "{{ user_language }}"
         const forwardingUrl = "{{ forwarding_url }}";
         const noticeId = {{ notice_id }};
         const inApp = "{{ in_app }}" === "True" ? true : false;
@@ -38,4 +39,3 @@
     {% csrf_token %}
 </body>
 </html>
-


### PR DESCRIPTION
**Description:**
Passes the user’s language code to the frontend for use in the JavaScript of the template.

See this in use in the accompanying PR here: https://github.com/edx/notices-internal/pull/15

**Merge checklist:**
- [x] Bump version
- [x] Add to changelog
- [ ] Update docs (not only docstrings)

**Post merge:**
(Will eventually be handled via automation)
- [ ] Release with new tag matching version