### PR TITLE
chore: fix automation workflows

### DIFF
--- a/.github/workflows/create_edx_internal_pr.yml
+++ b/.github/workflows/create_edx_internal_pr.yml
@@ -27,7 +27,7 @@ jobs:
           git config user.email "edx-deployment@edx.org"
           git config user.name "Edx Deployment automation robot"
           RELEASE_TAG=${GITHUB_REF#refs/tags/}
-          sed -i -e "s|platform-plugin-notices.git@.*|platform-plugin-notices.git@$RELEASE_TAG#egg=notices|" ansible/vars/edx.yml
+          sed -i -e "s|platform-plugin-notices.git@.*|platform-plugin-notices.git@$RELEASE_TAG#egg=edx-notices|" ansible/vars/edx.yml
           git add ansible/vars/edx.yml
           git commit -m "chore: bump notices plugin to $RELEASE_TAG"
           git push --set-upstream origin edx-deployment/notices/$GITHUB_SHA

--- a/.github/workflows/create_tag_on_merge_to_main.yml
+++ b/.github/workflows/create_tag_on_merge_to_main.yml
@@ -22,6 +22,6 @@ jobs:
         run: |
           git config user.email "edx-deployment@edx.org"
           git config user.name "Edx Deployment automation robot"
-          current_version=$(cat ./notices/__init__.py | grep "__version__" | sed "s|.*\([0-9]*\.[0-9]*\.[0-9]*\).*|\1|g")
-          git tag -a -m 'Release $current_version' $current_version HEAD
+          current_version=$(cat ./notices/__init__.py | grep "__version__" | sed "s|.*\([0-9]\.[0-9]*\.[0-9]*\).*|\1|g")
+          git tag -a -m 'Release v$current_version' v$current_version HEAD
           git push --follow-tags


### PR DESCRIPTION
Commits to main should now tag the commit with the version number in
__init__.py. edx-internal PRs should now use the right tag format.

**Description:**
Describe in a couple of sentences what this PR adds

**Merge checklist:**
- [ ] Bump version
- [ ] Add to changelog
- [ ] Update docs (not only docstrings)

**Post merge:**
(Will eventually be handled via automation)
- [ ] Release with new tag matching version

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
