### PR TITLE
fix: pin `tomli` to versions < 2.0.0 to fix Python requirements update action

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,15 +10,15 @@ certifi==2021.10.8
     # via requests
 cffi==1.15.0
     # via cryptography
-charset-normalizer==2.0.8
+charset-normalizer==2.0.9
     # via requests
 click==8.0.3
     # via code-annotations
 code-annotations==1.2.0
     # via edx-toggles
-cryptography==36.0.0
+cryptography==36.0.1
     # via pyjwt
-django==3.2.9
+django==3.2.10
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
@@ -44,7 +44,7 @@ django-waffle==2.2.1
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
-djangorestframework==3.12.4
+djangorestframework==3.13.1
     # via
     #   django-rest-framework
     #   drf-jwt
@@ -77,7 +77,7 @@ psutil==5.8.0
     # via edx-django-utils
 pycparser==2.21
     # via cffi
-pycryptodomex==3.11.0
+pycryptodomex==3.12.0
     # via pyjwkest
 pyjwkest==1.4.2
     # via edx-drf-extensions
@@ -85,14 +85,16 @@ pyjwt[crypto]==2.3.0
     # via
     #   drf-jwt
     #   edx-drf-extensions
-pymongo==4.0
+pymongo==4.0.1
     # via edx-opaque-keys
 python-dateutil==2.8.2
     # via edx-drf-extensions
 python-slugify==5.0.2
     # via code-annotations
 pytz==2021.3
-    # via django
+    # via
+    #   django
+    #   djangorestframework
 pyyaml==6.0
     # via code-annotations
 requests==2.26.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -8,13 +8,13 @@ backports.entry-points-selectable==1.1.1
     # via virtualenv
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.8
+charset-normalizer==2.0.9
     # via requests
 codecov==2.1.12
     # via -r requirements/ci.in
 coverage==6.2
     # via codecov
-distlib==0.3.3
+distlib==0.3.4
     # via virtualenv
 filelock==3.4.0
     # via
@@ -26,10 +26,8 @@ packaging==21.3
     # via tox
 platformdirs==2.4.0
     # via virtualenv
-pluggy==0.13.1
-    # via
-    #   -c requirements/constraints.txt
-    #   tox
+pluggy==1.0.0
+    # via tox
 py==1.11.0
     # via tox
 pyparsing==3.0.6

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,7 +11,6 @@
 # Common constraints for edx repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
 
-
-# pluggy released v 1.0.0 on 2021/08/25 but pytest 6.2.x currently requires pluggy<1.0.0. This constraint will be
-# re-evaluated for removal in MICROBA-1473.
-pluggy<1.0.0
+# tomli released v2.0.0 but there are constraints issues between black and coverage. This constraints will be
+# re-evaluated for removal in MICROBA-1634
+tomli<2.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,7 +21,7 @@ backports.entry-points-selectable==1.1.1
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-black==21.11b1
+black==21.12b0
     # via -r requirements/quality.txt
 bleach==4.1.0
     # via
@@ -38,7 +38,7 @@ cffi==1.15.0
     #   cryptography
 chardet==4.0.0
     # via diff-cover
-charset-normalizer==2.0.8
+charset-normalizer==2.0.9
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -73,18 +73,17 @@ coverage[toml]==6.2
     #   -r requirements/quality.txt
     #   codecov
     #   pytest-cov
-cryptography==36.0.0
+cryptography==36.0.1
     # via
     #   -r requirements/quality.txt
     #   pyjwt
-    #   secretstorage
-diff-cover==6.4.3
+diff-cover==6.4.4
     # via -r requirements/dev.in
-distlib==0.3.3
+distlib==0.3.4
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==3.2.9
+django==3.2.10
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
@@ -113,7 +112,7 @@ django-waffle==2.2.1
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
-djangorestframework==3.12.4
+djangorestframework==3.13.1
     # via
     #   -r requirements/quality.txt
     #   django-rest-framework
@@ -146,7 +145,7 @@ edx-toggles==4.2.0
     # via -r requirements/quality.txt
 factory-boy==3.2.1
     # via -r requirements/quality.txt
-faker==9.9.0
+faker==10.0.0
     # via
     #   -r requirements/quality.txt
     #   factory-boy
@@ -164,7 +163,7 @@ idna==3.3
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-importlib-metadata==4.8.2
+importlib-metadata==4.9.0
     # via
     #   -r requirements/quality.txt
     #   keyring
@@ -177,11 +176,6 @@ isort==5.10.1
     # via
     #   -r requirements/quality.txt
     #   pylint
-jeepney==0.7.1
-    # via
-    #   -r requirements/quality.txt
-    #   keyring
-    #   secretstorage
 jinja2==3.0.3
     # via
     #   -r requirements/quality.txt
@@ -191,7 +185,7 @@ keyring==23.4.0
     # via
     #   -r requirements/quality.txt
     #   twine
-lazy-object-proxy==1.6.0
+lazy-object-proxy==1.7.1
     # via
     #   -r requirements/quality.txt
     #   astroid
@@ -245,9 +239,8 @@ platformdirs==2.4.0
     #   black
     #   pylint
     #   virtualenv
-pluggy==0.13.1
+pluggy==1.0.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   diff-cover
@@ -271,7 +264,7 @@ pycparser==2.21
     # via
     #   -r requirements/quality.txt
     #   cffi
-pycryptodomex==3.11.0
+pycryptodomex==3.12.0
     # via
     #   -r requirements/quality.txt
     #   pyjwkest
@@ -291,7 +284,7 @@ pyjwt[crypto]==2.3.0
     #   -r requirements/quality.txt
     #   drf-jwt
     #   edx-drf-extensions
-pylint==2.12.1
+pylint==2.12.2
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -311,7 +304,7 @@ pylint-plugin-utils==0.6
     #   -r requirements/quality.txt
     #   pylint-celery
     #   pylint-django
-pymongo==4.0
+pymongo==4.0.1
     # via
     #   -r requirements/quality.txt
     #   edx-opaque-keys
@@ -327,7 +320,7 @@ pytest==6.2.5
     #   pytest-django
 pytest-cov==3.0.0
     # via -r requirements/quality.txt
-pytest-django==4.5.1
+pytest-django==4.5.2
     # via -r requirements/quality.txt
 python-dateutil==2.8.2
     # via
@@ -342,19 +335,16 @@ pytz==2021.3
     # via
     #   -r requirements/quality.txt
     #   django
+    #   djangorestframework
 pyyaml==6.0
     # via
     #   -r requirements/quality.txt
     #   code-annotations
     #   edx-i18n-tools
-readme-renderer==30.0
+readme-renderer==32.0
     # via
     #   -r requirements/quality.txt
     #   twine
-regex==2021.11.10
-    # via
-    #   -r requirements/quality.txt
-    #   black
 requests==2.26.0
     # via
     #   -r requirements/ci.txt
@@ -372,10 +362,6 @@ rfc3986==1.5.0
     # via
     #   -r requirements/quality.txt
     #   twine
-secretstorage==3.3.1
-    # via
-    #   -r requirements/quality.txt
-    #   keyring
 semantic-version==2.8.5
     # via
     #   -r requirements/quality.txt
@@ -417,8 +403,9 @@ toml==0.10.2
     #   pylint
     #   pytest
     #   tox
-tomli==1.2.2
+tomli==1.2.3
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
     #   black
@@ -434,7 +421,7 @@ tqdm==4.62.3
     # via
     #   -r requirements/quality.txt
     #   twine
-twine==3.7.0
+twine==3.7.1
     # via -r requirements/quality.txt
 typing-extensions==4.0.1
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -26,7 +26,7 @@ cffi==1.15.0
     # via
     #   -r requirements/test.txt
     #   cryptography
-charset-normalizer==2.0.8
+charset-normalizer==2.0.9
     # via
     #   -r requirements/test.txt
     #   requests
@@ -42,11 +42,11 @@ coverage[toml]==6.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==36.0.0
+cryptography==36.0.1
     # via
     #   -r requirements/test.txt
     #   pyjwt
-django==3.2.9
+django==3.2.10
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -74,7 +74,7 @@ django-waffle==2.2.1
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
-djangorestframework==3.12.4
+djangorestframework==3.13.1
     # via
     #   -r requirements/test.txt
     #   django-rest-framework
@@ -109,7 +109,7 @@ edx-toggles==4.2.0
     # via -r requirements/test.txt
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==9.9.0
+faker==10.0.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -150,9 +150,8 @@ pbr==5.8.0
     # via
     #   -r requirements/test.txt
     #   stevedore
-pluggy==0.13.1
+pluggy==1.0.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   pytest
 psutil==5.8.0
@@ -167,7 +166,7 @@ pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
-pycryptodomex==3.11.0
+pycryptodomex==3.12.0
     # via
     #   -r requirements/test.txt
     #   pyjwkest
@@ -185,7 +184,7 @@ pyjwt[crypto]==2.3.0
     #   -r requirements/test.txt
     #   drf-jwt
     #   edx-drf-extensions
-pymongo==4.0
+pymongo==4.0.1
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
@@ -200,7 +199,7 @@ pytest==6.2.5
     #   pytest-django
 pytest-cov==3.0.0
     # via -r requirements/test.txt
-pytest-django==4.5.1
+pytest-django==4.5.2
     # via -r requirements/test.txt
 python-dateutil==2.8.2
     # via
@@ -216,11 +215,12 @@ pytz==2021.3
     #   -r requirements/test.txt
     #   babel
     #   django
+    #   djangorestframework
 pyyaml==6.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
-readme-renderer==30.0
+readme-renderer==32.0
     # via -r requirements/doc.in
 requests==2.26.0
     # via
@@ -280,8 +280,9 @@ toml==0.10.2
     # via
     #   -r requirements/test.txt
     #   pytest
-tomli==1.2.2
+tomli==1.2.3
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   coverage
 urllib3==1.26.7

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -10,8 +10,10 @@ pep517==0.12.0
     # via pip-tools
 pip-tools==6.4.0
     # via -r requirements/pip-tools.in
-tomli==1.2.2
-    # via pep517
+tomli==1.2.3
+    # via
+    #   -c requirements/constraints.txt
+    #   pep517
 wheel==0.37.0
     # via pip-tools
 

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -16,7 +16,7 @@ attrs==21.2.0
     # via
     #   -r requirements/test.txt
     #   pytest
-black==21.11b1
+black==21.12b0
     # via -r requirements/quality.in
 bleach==4.1.0
     # via readme-renderer
@@ -28,7 +28,7 @@ cffi==1.15.0
     # via
     #   -r requirements/test.txt
     #   cryptography
-charset-normalizer==2.0.8
+charset-normalizer==2.0.9
     # via
     #   -r requirements/test.txt
     #   requests
@@ -52,12 +52,11 @@ coverage[toml]==6.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==36.0.0
+cryptography==36.0.1
     # via
     #   -r requirements/test.txt
     #   pyjwt
-    #   secretstorage
-django==3.2.9
+django==3.2.10
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -85,7 +84,7 @@ django-waffle==2.2.1
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
-djangorestframework==3.12.4
+djangorestframework==3.13.1
     # via
     #   -r requirements/test.txt
     #   django-rest-framework
@@ -114,7 +113,7 @@ edx-toggles==4.2.0
     # via -r requirements/test.txt
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==9.9.0
+faker==10.0.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -126,7 +125,7 @@ idna==3.3
     # via
     #   -r requirements/test.txt
     #   requests
-importlib-metadata==4.8.2
+importlib-metadata==4.9.0
     # via
     #   keyring
     #   twine
@@ -138,17 +137,13 @@ isort==5.10.1
     # via
     #   -r requirements/quality.in
     #   pylint
-jeepney==0.7.1
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.0.3
     # via
     #   -r requirements/test.txt
     #   code-annotations
 keyring==23.4.0
     # via twine
-lazy-object-proxy==1.6.0
+lazy-object-proxy==1.7.1
     # via astroid
 markupsafe==2.0.1
     # via
@@ -179,9 +174,8 @@ platformdirs==2.4.0
     # via
     #   black
     #   pylint
-pluggy==0.13.1
+pluggy==1.0.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   pytest
 psutil==5.8.0
@@ -198,7 +192,7 @@ pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
-pycryptodomex==3.11.0
+pycryptodomex==3.12.0
     # via
     #   -r requirements/test.txt
     #   pyjwkest
@@ -215,7 +209,7 @@ pyjwt[crypto]==2.3.0
     #   -r requirements/test.txt
     #   drf-jwt
     #   edx-drf-extensions
-pylint==2.12.1
+pylint==2.12.2
     # via
     #   edx-lint
     #   pylint-celery
@@ -229,7 +223,7 @@ pylint-plugin-utils==0.6
     # via
     #   pylint-celery
     #   pylint-django
-pymongo==4.0
+pymongo==4.0.1
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
@@ -244,7 +238,7 @@ pytest==6.2.5
     #   pytest-django
 pytest-cov==3.0.0
     # via -r requirements/test.txt
-pytest-django==4.5.1
+pytest-django==4.5.2
     # via -r requirements/test.txt
 python-dateutil==2.8.2
     # via
@@ -259,14 +253,13 @@ pytz==2021.3
     # via
     #   -r requirements/test.txt
     #   django
+    #   djangorestframework
 pyyaml==6.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
-readme-renderer==30.0
+readme-renderer==32.0
     # via twine
-regex==2021.11.10
-    # via black
 requests==2.26.0
     # via
     #   -r requirements/test.txt
@@ -278,8 +271,6 @@ requests-toolbelt==0.9.1
     # via twine
 rfc3986==1.5.0
     # via twine
-secretstorage==3.3.1
-    # via keyring
 semantic-version==2.8.5
     # via
     #   -r requirements/test.txt
@@ -314,14 +305,15 @@ toml==0.10.2
     #   -r requirements/test.txt
     #   pylint
     #   pytest
-tomli==1.2.2
+tomli==1.2.3
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   black
     #   coverage
 tqdm==4.62.3
     # via twine
-twine==3.7.0
+twine==3.7.1
     # via -r requirements/quality.in
 typing-extensions==4.0.1
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -18,7 +18,7 @@ cffi==1.15.0
     # via
     #   -r requirements/base.txt
     #   cryptography
-charset-normalizer==2.0.8
+charset-normalizer==2.0.9
     # via
     #   -r requirements/base.txt
     #   requests
@@ -33,7 +33,7 @@ code-annotations==1.2.0
     #   edx-toggles
 coverage[toml]==6.2
     # via pytest-cov
-cryptography==36.0.0
+cryptography==36.0.1
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -64,7 +64,7 @@ django-waffle==2.2.1
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
-djangorestframework==3.12.4
+djangorestframework==3.13.1
     # via
     #   -r requirements/base.txt
     #   django-rest-framework
@@ -89,7 +89,7 @@ edx-toggles==4.2.0
     # via -r requirements/base.txt
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==9.9.0
+faker==10.0.0
     # via factory-boy
 future==0.18.2
     # via
@@ -119,10 +119,8 @@ pbr==5.8.0
     # via
     #   -r requirements/base.txt
     #   stevedore
-pluggy==0.13.1
-    # via
-    #   -c requirements/constraints.txt
-    #   pytest
+pluggy==1.0.0
+    # via pytest
 psutil==5.8.0
     # via
     #   -r requirements/base.txt
@@ -133,7 +131,7 @@ pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   cffi
-pycryptodomex==3.11.0
+pycryptodomex==3.12.0
     # via
     #   -r requirements/base.txt
     #   pyjwkest
@@ -146,7 +144,7 @@ pyjwt[crypto]==2.3.0
     #   -r requirements/base.txt
     #   drf-jwt
     #   edx-drf-extensions
-pymongo==4.0
+pymongo==4.0.1
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -158,7 +156,7 @@ pytest==6.2.5
     #   pytest-django
 pytest-cov==3.0.0
     # via -r requirements/test.in
-pytest-django==4.5.1
+pytest-django==4.5.2
     # via -r requirements/test.in
 python-dateutil==2.8.2
     # via
@@ -173,6 +171,7 @@ pytz==2021.3
     # via
     #   -r requirements/base.txt
     #   django
+    #   djangorestframework
 pyyaml==6.0
     # via
     #   -r requirements/base.txt
@@ -209,8 +208,10 @@ text-unidecode==1.3
     #   python-slugify
 toml==0.10.2
     # via pytest
-tomli==1.2.2
-    # via coverage
+tomli==1.2.3
+    # via
+    #   -c requirements/constraints.txt
+    #   coverage
 urllib3==1.26.7
     # via
     #   -r requirements/base.txt


### PR DESCRIPTION
**Description:**
* pins `tomli` to versions < 2.0.0 to fix the Python requirements update action
* remove pin constraint for `pluggy` which is no longer needed