### PR TITLE
fix: Do not redirect render to login on mobile 403 mobile request

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.14.4] - 2022-02-14
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Changed Do not redirect notices/render/{id}/ to login page in case of 403 on mobile request
+
 [0.14.3] - 2022-02-07
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Update pip-tools

--- a/notices/__init__.py
+++ b/notices/__init__.py
@@ -2,6 +2,6 @@
 An edx-platform plugin which manages notices that must be acknowledged.
 """
 
-__version__ = "0.14.3"
+__version__ = "0.14.4"
 
 default_app_config = "notices.apps.NoticesConfig"  # pylint: disable=invalid-name

--- a/notices/views.py
+++ b/notices/views.py
@@ -29,7 +29,7 @@ class RenderNotice(LoginRequiredMixin, DetailView):
 
     def handle_no_permission(self):
         """If mobile=true in get params then don't redirect to login page."""
-        if self.request.query_params.get("mobile") == "true":
+        if self.request.GET.get("mobile") == "true":
             raise PermissionDenied("Authentication failed. Login to access notice")
 
         return super().handle_no_permission()

--- a/notices/views.py
+++ b/notices/views.py
@@ -7,7 +7,7 @@ from urllib.parse import unquote, urlsplit
 
 from django.conf import settings
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.utils.translation import get_language_from_request
 from django.views.generic import DetailView
 
@@ -26,6 +26,13 @@ class RenderNotice(LoginRequiredMixin, DetailView):
     # (e.g., courses, programs).
     template_name = "notice.html"
     model = Notice
+
+    def handle_no_permission(self):
+        """If mobile=true in get params then don't redirect to login page."""
+        if self.request.query_params.get("mobile") == "true":
+            raise PermissionDenied("Authentication failed. Login to access notice")
+
+        return super().handle_no_permission()
 
     def get_context_data(self, **kwargs):
         """


### PR DESCRIPTION
Do not redirect render to login on mobile 403 mobile request

**Description:**
Do not redirect notices/render/*/?mobile=true to login page in case user is not logged in
For mobile we will use token based authentication therefore no need for redirection.

JIRA Ticket [LEARNER-8698](https://openedx.atlassian.net/browse/LEARNER-8698)

**Merge checklist:**
- [x] Bump version
- [x] Add to changelog
- [ ] Update docs (not only docstrings)

**Post merge:**
(Will eventually be handled via automation)
- [ ] Release with new tag matching version

