### PR TITLE
chore: unpin tomli

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,7 +10,3 @@
 
 # Common constraints for edx repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-
-# tomli released v2.0.0 but there are constraints issues between black and coverage. This constraints will be
-# re-evaluated for removal in MICROBA-1634
-tomli<2.0.0


### PR DESCRIPTION
**Description:**
[MICROBA-1634]

* unpin `tomli` in the notices plugin, the constraint is no longer needed.

A few months ago `black` and `coverage` wanted different versions of `tomli` and we had to pin a constraint to ensure the `make upgrade` target was working. It looks like this is no longer needed as `make upgrade` completes successfully without the constraint.