### PR TITLE
chore: adjust `upgrade requirements` job to run on Monday

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -2,8 +2,8 @@ name: Upgrade Requirements
 
 on:
   schedule:
-    # will start the job at 13:15 UTC every Friday
-    - cron: "15 13 * * 5"
+    # will start the job at 13:15 UTC (09:15 EST) every Monday
+    - cron: "15 13 * * 1"
   workflow_dispatch:
     inputs:
       branch:


### PR DESCRIPTION
**Description:**

* Adjusts the cron schedule of the `upgrade-python-requirements` job to run on Mondays.