### PR TITLE
fix: fix version bumping GH action automation by updating regex

### DIFF
--- a/.github/workflows/patch_version_on_requirements_update.yml
+++ b/.github/workflows/patch_version_on_requirements_update.yml
@@ -26,7 +26,7 @@ jobs:
       # Bump patch version in branch by one
       - name: Update version
         run: |
-          current_patch_version=$(cat ./notices/__init__.py | grep "__version__" | sed "s|.*[0-9]\.[0-9]\.\([0-9]*\).*|\1|g")
+          current_patch_version=$(cat ./notices/__init__.py | grep "__version__" | sed "s|.*[0-9]\.*[0-9]\.\([0-9]*\).*|\1|g")
           new_patch_version=$((current_patch_version+1))
           sed -i "s|\(__version__ = \"[0-9]*\.[0-9]*\.\)[0-9]*|\1$new_patch_version|g" ./notices/__init__.py
       # Set identity, commit change, squash, and push


### PR DESCRIPTION
**Description:**
* regex is not dealing with multi-digit middle numbers correctly and results in the version number not being updated correctly