### PR TITLE
-t flag added in pull translation command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ detect_changed_source_translations:
 	cd notices && i18n_tool changed
 
 pull_translations: ## pull translations from Transifex
-	tx pull -af --mode reviewed
+	tx pull -t -af --mode reviewed
 
 push_translations: ## push source translation files (.po) from Transifex
 	tx push -s


### PR DESCRIPTION
The transifex command line tool we use to pull translations introduced a fix that broke the existing translation pulls.
So, in order to fix this, I've updated the` tx pull `command to use the `-t` flag along with the existing flags.

To get the more context on this, please have a look into this [issue](https://github.com/edx/edx-arch-experiments/issues/77)