### PR TITLE
build: remove unnecessary codecov dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         # Although code coverage is a "quality" concern, we need the coverage report that only exists after running the
         # test suite, and this allows us to not run it twice.
         if: matrix.python-version == '3.8' && matrix.toxenv == 'py38'
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           flags: unittests
           fail_ci_if_error: true

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -1,5 +1,4 @@
 # Requirements for running tests on CI
 -c constraints.txt
 
-codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -8,8 +8,6 @@ certifi==2022.12.7
     # via requests
 charset-normalizer==3.1.0
     # via requests
-codecov==2.1.12
-    # via -r requirements/ci.in
 coverage==7.2.3
     # via codecov
 distlib==0.3.6

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -59,8 +59,6 @@ code-annotations==1.3.0
     #   -r requirements/quality.txt
     #   edx-lint
     #   edx-toggles
-codecov==2.1.12
-    # via -r requirements/ci.txt
 coverage[toml]==7.2.3
     # via
     #   -r requirements/ci.txt


### PR DESCRIPTION
**Description:**
On Wednesday this happened with Codecov: https://about.codecov.io/blog/message-regarding-the-pypi-package/

Since codecov's GHA-based uploader doesn't depend on this package, this PR removes it.