### PR TITLE
chore: update team name in upgrade-requirements workflow

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -52,7 +52,7 @@ jobs:
           --target-branch="${{ env.target_branch }}" --base-branch-name="upgrade-python-requirements" \
           --commit-message="chore: Updating Python Requirements" --pr-title="Python Requirements Update" \
           --pr-body="Python requirements update.Please review the [changelogs](https://openedx.atlassian.net/wiki/spaces/TE/pages/1001521320/Python+Package+Changelogs) for the upgraded packages." \
-          --user-reviewers="" --team-reviewers="edx-aperture" --delete-old-pull-requests
+          --user-reviewers="" --team-reviewers="edx-infinity" --delete-old-pull-requests
 
       - name: Send failure notification
         if: ${{ failure() }}


### PR DESCRIPTION
**Description:**
[APER-2679]

Update team name in `upgrade-requirements` workflow from `edx-aperture` to `edx-infinity`.

**Merge checklist:**
- [ ] Bump version
- [ ] Add to changelog
- [ ] Update docs (not only docstrings)

**Post merge:**
(Will eventually be handled via automation)
- [ ] Release with new tag matching version

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
